### PR TITLE
Add splunk_server=local to rest commands

### DIFF
--- a/default/data/ui/views/map_rule_to_technique.xml
+++ b/default/data/ui/views/map_rule_to_technique.xml
@@ -7,7 +7,7 @@
       <fieldForLabel>rule_name</fieldForLabel>
       <fieldForValue>rule_name</fieldForValue>
       <search>
-        <query>| rest services/configs/conf-savedsearches
+        <query>| rest splunk_server=local /services/configs/conf-savedsearches
 | eval rule_name=title
 | eval rule_disabled=disabled
 | table rule_name</query>

--- a/default/data/ui/views/mitre_compliance.xml
+++ b/default/data/ui/views/mitre_compliance.xml
@@ -28,12 +28,12 @@
       <table id="mitre_status_table">
         <title>MITRE ATT&amp;CK Compliance Lookup Gen Status</title>
         <search>
-          <query>| rest /services/saved/searches/
+          <query>| rest splunk_server=local /services/saved/searches/
 | search title="MITRE ATT&amp;CK Compliance Lookup Gen" splunk_server = local
 | fields title, next_scheduled_time, updated
 | rename title as "Lookup Generator Name", next_scheduled_time as "Next Scheduled Run", updated as "Last Scheduled Run"
 | join "Lookup Generator Name" type=left
-    [| rest /services/data/lookup-table-files
+    [| rest splunk_server=local /services/data/lookup-table-files
     | search title = "mitre_all_rule_compliance_lookup.csv"
     | fields title, updated
     | rename title as "Lookup Table Name", updated as "Time of Latest Lookup Table Update"

--- a/default/data/ui/views/mitre_threat_actor_compliance.xml
+++ b/default/data/ui/views/mitre_threat_actor_compliance.xml
@@ -35,12 +35,12 @@
       <table id="mitre_status_table">
         <title>MITRE ATT&amp;CK Compliance Lookup Gen Status</title>
         <search>
-          <query>| rest /services/saved/searches/
+          <query>| rest splunk_server=local /services/saved/searches/
 | search title="MITRE ATT&amp;CK Compliance Lookup Gen"
 | fields title, next_scheduled_time, updated
 | rename title as "Lookup Generator Name", next_scheduled_time as "Next Scheduled Run", updated as "Last Scheduled Run"
 | join "Lookup Generator Name" type=left
-    [| rest /services/data/lookup-table-files
+    [| rest splunk_server=local /services/data/lookup-table-files
     | search title = "mitre_all_rule_compliance_lookup.csv"
     | fields title, updated
     | rename title as "Lookup Table Name", updated as "Time of Latest Lookup Table Update"

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -11,7 +11,7 @@ action.threat_add.param.verbose = 0
 alert.track = 0
 cron_schedule = 1 0 * * *
 enableSched = 1
-search = | rest /services/configs/conf-analyticstories \
+search = | rest splunk_server=local /services/configs/conf-analyticstories \
 | where annotations!="" \
 | spath input=annotations path=mitre_attack{} output=mitre_attack \
 | eval rule_name=ltrim(title,"savedsearch://") \
@@ -19,7 +19,7 @@ search = | rest /services/configs/conf-analyticstories \
 | search NOT [| outputlookup mitre_app_rule_technique_lookup append=true] \
 | fields rule_name,mitre_attack \
 | join rule_name \
-    [| rest /services/configs/conf-analyticstories \
+    [| rest splunk_server=local /services/configs/conf-analyticstories \
     | where searches!="" \
     | eval rule_name=searches \
     | table title,rule_name \
@@ -31,7 +31,7 @@ search = | rest /services/configs/conf-analyticstories \
     | eval rule_name=trim(rule_name,"\"")\
         ] \
 | append \
-    [| rest services/configs/conf-savedsearches \
+    [| rest splunk_server=local /services/configs/conf-savedsearches \
     | eval rule_name=title \
     | search action.correlationsearch.annotations="*" \
     | spath input=action.correlationsearch.annotations path=mitre_attack{} output=mitre_attack \
@@ -48,7 +48,7 @@ search = | rest /services/configs/conf-analyticstories \
 | mvexpand technique_id \
 | dedup rule_name,technique_id \
 | join rule_name \
-    [| rest services/configs/conf-savedsearches \
+    [| rest splunk_server=local /services/configs/conf-savedsearches \
     | eval rule_name=title \
     | eval rule_disabled=disabled \
     | rename eai:acl.app as app_name\


### PR DESCRIPTION
This PR adds the `splunk_server=local` parameter to `rest` commands.

This ensures no warnings like below appear, when the app is installed on a Splunk Cloud stack:
```
Restricting results of the "rest" operator to the local instance because you do not have the "dispatch_rest_to_indexers" capability.
```